### PR TITLE
Updated README including information regarding Health app data permissions for first time users

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ Done!
 > [!NOTE]
 > These shortcuts are designed for iPhone, and will not run on MacOS as there is no native Apple Health API available.
 
+> [!NOTE]
+> The Shortcuts app must have explicit permission to write data to the Health app for each of the samples (HRV, SpO2, etc.). If Shortcuts has never attempted to write to Health before, this option will not be available in the Health permissions settings. To fix this, run the shortcut manually, allow it to fail, and return to the Health permissions settings to enable the appropriate permissions. At this point, your automation should work as expected. You can access the Health permissions settings by going to the Health app, selecting your profile in the top right, selecting 'Apps' under the 'Privacy' section, and then selecting 'Shortcuts.'.
+
 ## Notes <a name="notes"></a>
 
 ### Heart Rate Variability <a name="hrv"></a>


### PR DESCRIPTION
I have updated the README to communicate the need for explicit sample permissions in the iOS Health app, including some instructions on how to trigger and enable them.

As of iOS 18.1, if you attempt to run this shortcuts for the first time, the Shortcuts app will **not** request access to the Health data, instead it simply throws an error pop up message. The user needs to manually enable it, which is only possible after first attempting to write the specific sample to Health. For these reasons I think it'd be helpful to direct the user of this shortcuts through the correct path.

Feel free to use a different callout type or include this information in a different place :)